### PR TITLE
Improve task forms, urgency colors

### DIFF
--- a/src/components/TaskItem.js
+++ b/src/components/TaskItem.js
@@ -33,7 +33,13 @@ export default function TaskItem({ task, onComplete }) {
       </View>
       <View style={styles.urgency}>
         {[1,2,3,4,5].map(l => (
-          <View key={l} style={[styles.dot, {backgroundColor: l <= urgency ? colorFor(l) : '#333'}]} />
+          <View
+            key={l}
+            style={[
+              styles.dot,
+              { backgroundColor: l <= urgency ? colorFor(urgency) : '#333' },
+            ]}
+          />
         ))}
       </View>
     </View>

--- a/src/components/UrgencyPicker.js
+++ b/src/components/UrgencyPicker.js
@@ -12,7 +12,14 @@ export default function UrgencyPicker({ value, onChange }) {
   return (
     <View style={styles.row}>
       {[1,2,3,4,5].map(l => (
-        <Pressable key={l} onPress={() => onChange(l)} style={[styles.circle, {backgroundColor: l <= value ? colorFor(l) : '#555'}]} />
+        <Pressable
+          key={l}
+          onPress={() => onChange(l)}
+          style={[
+            styles.circle,
+            { backgroundColor: l <= value ? colorFor(value) : '#555' },
+          ]}
+        />
       ))}
     </View>
   );

--- a/src/screens/TasksScreen.js
+++ b/src/screens/TasksScreen.js
@@ -75,9 +75,12 @@ export default function TasksScreen() {
                 onChange={(e, d) => {
                   setShowDurationPicker(false);
                   if (d) {
-                    const h = d.getHours().toString().padStart(2, '0');
-                    const m = d.getMinutes().toString().padStart(2, '0');
-                    setDuration(`${h}:${m}`);
+                    const hours = d.getHours();
+                    const minutes = d.getMinutes();
+                    const parts = [];
+                    if (hours) parts.push(`${hours}h`);
+                    if (minutes) parts.push(`${minutes}m`);
+                    setDuration(parts.join(' ') || '0m');
                   }
                 }}
               />
@@ -101,8 +104,10 @@ export default function TasksScreen() {
                 }}
               />
             )}
-            <Button title="Add" onPress={addTask} />
-            <Button title="Cancel" onPress={() => setShowForm(false)} />
+            <View style={styles.buttonRow}>
+              <Button title="Add" color="#bb86fc" onPress={addTask} />
+              <Button title="Cancel" color="#bb86fc" onPress={() => setShowForm(false)} />
+            </View>
           </View>
         </View>
       </Modal>
@@ -131,5 +136,9 @@ const styles = StyleSheet.create({
     padding: 16,
     borderRadius: 8,
     width: '90%',
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
   },
 });

--- a/src/screens/TodoScreen.js
+++ b/src/screens/TodoScreen.js
@@ -46,8 +46,10 @@ export default function TodoScreen() {
               value={text}
               onChangeText={setText}
             />
-            <Button title="Add" onPress={() => { addItem(); setShowForm(false); }} />
-            <Button title="Cancel" onPress={() => setShowForm(false)} />
+            <View style={styles.buttonRow}>
+              <Button title="Add" color="#bb86fc" onPress={() => { addItem(); setShowForm(false); }} />
+              <Button title="Cancel" color="#bb86fc" onPress={() => setShowForm(false)} />
+            </View>
           </View>
         </View>
       </Modal>
@@ -77,6 +79,10 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     width: '90%',
   },
+  buttonRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
   item: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -88,5 +94,6 @@ const styles = StyleSheet.create({
   },
   itemText: {
     fontSize: 16,
+    color: '#fff',
   },
 });


### PR DESCRIPTION
## Summary
- tweak duration picker to return hours/minutes
- layout add/cancel buttons side-by-side using app color
- color todo items text for dark theme
- color entire urgency matrix with selected level

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68402f1c189c8320a81862fe4dccc3b9