### PR TITLE
Fix gesture handler import for navigation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+import 'react-native-gesture-handler';
 import { registerRootComponent } from 'expo';
 import App from './src/App';
 import { registerWidget } from './src/widgets/HomeWidget';


### PR DESCRIPTION
## Summary
- add `react-native-gesture-handler` import to index.js to prevent top tab swipe crash

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68403e3bb234832098031cac4951f70e