### PR TITLE
Improve modal UX

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { NavigationContainer, DarkTheme } from '@react-navigation/native';
-import { StatusBar, View, Text, StyleSheet } from 'react-native';
+import { StatusBar, View, Text, StyleSheet, UIManager, Platform } from 'react-native';
 import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
 import FloatingActionButton from './components/FloatingActionButton';
 import TasksScreen from './screens/TasksScreen';
@@ -20,6 +20,12 @@ export default function App() {
   const [active, setActive] = useState('Tasks');
   const tasksRef = useRef();
   const todoRef = useRef();
+
+  useEffect(() => {
+    if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental) {
+      UIManager.setLayoutAnimationEnabledExperimental(true);
+    }
+  }, []);
 
   const handleFab = () => {
     if (active === 'Tasks') {

--- a/src/components/TaskItem.js
+++ b/src/components/TaskItem.js
@@ -48,7 +48,7 @@ export default function TaskItem({ task, onComplete, onPress }) {
       Animated.timing(anim, {
         toValue: 0,
         duration: 300,
-        useNativeDriver: true,
+        useNativeDriver: false,
       }).start();
     } else if (rowHeight !== null) {
       anim.setValue(0);
@@ -61,7 +61,7 @@ export default function TaskItem({ task, onComplete, onPress }) {
         Animated.timing(anim, {
           toValue: 1,
           duration: 300,
-          useNativeDriver: true,
+          useNativeDriver: false,
         }),
         Animated.timing(heightAnim, {
           toValue: 0,

--- a/src/components/TaskItem.js
+++ b/src/components/TaskItem.js
@@ -38,55 +38,31 @@ function computeUrgency(task) {
 export default function TaskItem({ task, onComplete, onPress }) {
   const [checked, setChecked] = React.useState(false);
   const anim = React.useRef(new Animated.Value(task.animateIn ? -1 : 0)).current;
-  const heightAnim = React.useRef(new Animated.Value(0)).current;
-  const marginAnim = React.useRef(new Animated.Value(6)).current;
-  const [rowHeight, setRowHeight] = React.useState(null);
   const urgency = computeUrgency(task);
 
   React.useEffect(() => {
-    if (task.animateIn && rowHeight !== null) {
+    if (task.animateIn) {
       Animated.timing(anim, {
         toValue: 0,
         duration: 300,
-        useNativeDriver: false,
+        useNativeDriver: true,
       }).start();
-    } else if (rowHeight !== null) {
-      anim.setValue(0);
     }
-  }, [rowHeight]);
+  }, []);
 
   React.useEffect(() => {
-    if (checked && rowHeight !== null) {
-      Animated.parallel([
-        Animated.timing(anim, {
-          toValue: 1,
-          duration: 300,
-          useNativeDriver: false,
-        }),
-        Animated.timing(heightAnim, {
-          toValue: 0,
-          duration: 300,
-          useNativeDriver: false,
-        }),
-        Animated.timing(marginAnim, {
-          toValue: 0,
-          duration: 300,
-          useNativeDriver: false,
-        }),
-      ]).start(() => onComplete());
+    if (checked) {
+      Animated.timing(anim, {
+        toValue: 1,
+        duration: 300,
+        useNativeDriver: true,
+      }).start(() => onComplete());
     }
-  }, [checked, rowHeight]);
+  }, [checked]);
 
   return (
     <TouchableOpacity activeOpacity={0.7} onPress={onPress}>
       <Animated.View
-        onLayout={(e) => {
-          if (rowHeight === null) {
-            const h = e.nativeEvent.layout.height;
-            heightAnim.setValue(h);
-            setRowHeight(h);
-          }
-        }}
         style={[
           styles.row,
           {
@@ -99,9 +75,6 @@ export default function TaskItem({ task, onComplete, onPress }) {
                 }),
               },
             ],
-            height: rowHeight !== null ? heightAnim : undefined,
-            marginVertical: rowHeight !== null ? marginAnim : 6,
-            overflow: 'hidden',
           },
         ]}
       >

--- a/src/components/TaskItem.js
+++ b/src/components/TaskItem.js
@@ -40,23 +40,23 @@ export default function TaskItem({ task, onComplete, onPress }) {
   const anim = React.useRef(new Animated.Value(task.animateIn ? -1 : 0)).current;
   const heightAnim = React.useRef(new Animated.Value(0)).current;
   const marginAnim = React.useRef(new Animated.Value(6)).current;
-  const [measured, setMeasured] = React.useState(false);
+  const [rowHeight, setRowHeight] = React.useState(null);
   const urgency = computeUrgency(task);
 
   React.useEffect(() => {
-    if (task.animateIn && measured) {
+    if (task.animateIn && rowHeight !== null) {
       Animated.timing(anim, {
         toValue: 0,
         duration: 300,
         useNativeDriver: true,
       }).start();
-    } else if (measured) {
+    } else if (rowHeight !== null) {
       anim.setValue(0);
     }
-  }, [measured]);
+  }, [rowHeight]);
 
   React.useEffect(() => {
-    if (checked && measured) {
+    if (checked && rowHeight !== null) {
       Animated.parallel([
         Animated.timing(anim, {
           toValue: 1,
@@ -75,15 +75,16 @@ export default function TaskItem({ task, onComplete, onPress }) {
         }),
       ]).start(() => onComplete());
     }
-  }, [checked, measured]);
+  }, [checked, rowHeight]);
 
   return (
     <TouchableOpacity activeOpacity={0.7} onPress={onPress}>
       <Animated.View
         onLayout={(e) => {
-          if (!measured) {
-            heightAnim.setValue(e.nativeEvent.layout.height);
-            setMeasured(true);
+          if (rowHeight === null) {
+            const h = e.nativeEvent.layout.height;
+            heightAnim.setValue(h);
+            setRowHeight(h);
           }
         }}
         style={[
@@ -98,8 +99,8 @@ export default function TaskItem({ task, onComplete, onPress }) {
                 }),
               },
             ],
-            height: heightAnim,
-            marginVertical: marginAnim,
+            height: rowHeight !== null ? heightAnim : undefined,
+            marginVertical: rowHeight !== null ? marginAnim : 6,
             overflow: 'hidden',
           },
         ]}

--- a/src/components/TaskItem.js
+++ b/src/components/TaskItem.js
@@ -38,8 +38,6 @@ function computeUrgency(task) {
 export default function TaskItem({ task, onComplete, onPress }) {
   const [checked, setChecked] = React.useState(false);
   const slideAnim = React.useRef(new Animated.Value(task.animateIn ? -1 : 0)).current;
-  const collapseAnim = React.useRef(new Animated.Value(1)).current;
-  const [rowHeight, setRowHeight] = React.useState(null);
   const urgency = computeUrgency(task);
 
   React.useEffect(() => {
@@ -54,39 +52,19 @@ export default function TaskItem({ task, onComplete, onPress }) {
 
   React.useEffect(() => {
     if (checked) {
-      Animated.parallel([
-        Animated.timing(slideAnim, {
-          toValue: 1,
-          duration: 300,
-          useNativeDriver: true,
-        }),
-        Animated.timing(collapseAnim, {
-          toValue: 0,
-          duration: 300,
-          useNativeDriver: false,
-        }),
-      ]).start(() => onComplete());
+      Animated.timing(slideAnim, {
+        toValue: 1,
+        duration: 300,
+        useNativeDriver: true,
+      }).start(onComplete);
     }
   }, [checked]);
 
   return (
     <TouchableOpacity activeOpacity={0.7} onPress={onPress}>
       <Animated.View
-        onLayout={(e) => {
-          if (rowHeight === null) setRowHeight(e.nativeEvent.layout.height);
-        }}
         style={[
           styles.row,
-          rowHeight != null && {
-            height: collapseAnim.interpolate({
-              inputRange: [0, 1],
-              outputRange: [0, rowHeight],
-            }),
-            marginVertical: collapseAnim.interpolate({
-              inputRange: [0, 1],
-              outputRange: [0, 6],
-            }),
-          },
           {
             opacity: slideAnim.interpolate({
               inputRange: [-1, 0, 1],

--- a/src/components/TodoItem.js
+++ b/src/components/TodoItem.js
@@ -5,8 +5,6 @@ import Checkbox from 'expo-checkbox';
 export default function TodoItem({ item, onToggle }) {
   const [checked, setChecked] = React.useState(false);
   const slideAnim = React.useRef(new Animated.Value(item.animateIn ? -1 : 0)).current;
-  const collapseAnim = React.useRef(new Animated.Value(1)).current;
-  const [rowHeight, setRowHeight] = React.useState(null);
 
   React.useEffect(() => {
     if (item.animateIn) {
@@ -20,32 +18,18 @@ export default function TodoItem({ item, onToggle }) {
 
   React.useEffect(() => {
     if (checked) {
-      Animated.parallel([
-        Animated.timing(slideAnim, {
-          toValue: 1,
-          duration: 300,
-          useNativeDriver: true,
-        }),
-        Animated.timing(collapseAnim, {
-          toValue: 0,
-          duration: 300,
-          useNativeDriver: false,
-        }),
-      ]).start(() => onToggle());
+      Animated.timing(slideAnim, {
+        toValue: 1,
+        duration: 300,
+        useNativeDriver: true,
+      }).start(onToggle);
     }
   }, [checked]);
 
   return (
     <Animated.View
-      onLayout={(e) => {
-        if (rowHeight === null) setRowHeight(e.nativeEvent.layout.height);
-      }}
       style={[
         styles.item,
-        rowHeight != null && {
-          height: collapseAnim.interpolate({ inputRange: [0, 1], outputRange: [0, rowHeight] }),
-          marginVertical: collapseAnim.interpolate({ inputRange: [0, 1], outputRange: [0, 6] }),
-        },
         {
           opacity: slideAnim.interpolate({ inputRange: [-1, 0, 1], outputRange: [0, 1, 0] }),
           transform: [

--- a/src/screens/TasksScreen.js
+++ b/src/screens/TasksScreen.js
@@ -7,6 +7,7 @@ import {
   StyleSheet,
   Modal,
   TouchableOpacity,
+  KeyboardAvoidingView,
   TouchableWithoutFeedback,
   LayoutAnimation,
 } from 'react-native';
@@ -240,7 +241,7 @@ const TasksScreen = forwardRef((props, ref) => {
         <TouchableWithoutFeedback onPress={() => { setShowForm(false); }}>
           <View style={styles.modalBackdrop}>
             <TouchableWithoutFeedback>
-              <View style={styles.modalContent}>
+              <KeyboardAvoidingView enabled={false} style={styles.modalContent}>
             <Text style={styles.modalLabel}>New Task</Text>
             <TextInput
               ref={titleInputRef}
@@ -311,10 +312,10 @@ const TasksScreen = forwardRef((props, ref) => {
               />
             )}
             <View style={styles.buttonRow}>
-              <AppButton title="Cancel" onPress={() => { setShowForm(false); setEditingTask(null); }} />
-              <AppButton title={editingTask ? 'Save' : 'Add'} onPress={saveTask} />
+              <AppButton title="Cancel" onPress={() => { titleInputRef.current?.blur(); setShowForm(false); setEditingTask(null); }} />
+              <AppButton title={editingTask ? 'Save' : 'Add'} onPress={() => { saveTask(); titleInputRef.current?.blur(); }} />
             </View>
-              </View>
+              </KeyboardAvoidingView>
             </TouchableWithoutFeedback>
           </View>
         </TouchableWithoutFeedback>

--- a/src/screens/TasksScreen.js
+++ b/src/screens/TasksScreen.js
@@ -9,7 +9,6 @@ import {
   TouchableOpacity,
   KeyboardAvoidingView,
   TouchableWithoutFeedback,
-  LayoutAnimation,
 } from 'react-native';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import TaskItem from '../components/TaskItem';
@@ -152,7 +151,6 @@ const TasksScreen = forwardRef((props, ref) => {
   };
 
   const completeTask = (id) => {
-    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
     const removed = tasks.find(t => t.id === id);
     const newTasks = sortTasks(tasks.filter(t => t.id !== id));
     setTasks(newTasks);

--- a/src/screens/TasksScreen.js
+++ b/src/screens/TasksScreen.js
@@ -9,6 +9,7 @@ import {
   TouchableOpacity,
   KeyboardAvoidingView,
   TouchableWithoutFeedback,
+  LayoutAnimation,
 } from 'react-native';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import TaskItem from '../components/TaskItem';
@@ -151,6 +152,7 @@ const TasksScreen = forwardRef((props, ref) => {
   };
 
   const completeTask = (id) => {
+    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
     const removed = tasks.find(t => t.id === id);
     const newTasks = sortTasks(tasks.filter(t => t.id !== id));
     setTasks(newTasks);

--- a/src/screens/TasksScreen.js
+++ b/src/screens/TasksScreen.js
@@ -7,6 +7,7 @@ import {
   StyleSheet,
   Modal,
   TouchableOpacity,
+  TouchableWithoutFeedback,
   LayoutAnimation,
 } from 'react-native';
 import DateTimePicker from '@react-native-community/datetimepicker';
@@ -62,6 +63,7 @@ const TasksScreen = forwardRef((props, ref) => {
   const [sortMode, setSortMode] = useState('priority');
   const [deletedTasks, setDeletedTasks] = useState([]);
   const [showHistory, setShowHistory] = useState(false);
+  const titleInputRef = React.useRef();
 
   const persistTasks = (list) => {
     AsyncStorage.setItem(
@@ -228,43 +230,71 @@ const TasksScreen = forwardRef((props, ref) => {
         contentContainerStyle={{ paddingBottom: 120 }}
       />
 
-      <Modal visible={showForm} animationType="slide" transparent onRequestClose={() => setShowForm(false)}>
-        <View style={styles.modalBackdrop}>
-          <View style={styles.modalContent}>
+      <Modal
+        visible={showForm}
+        animationType="slide"
+        transparent
+        presentationStyle="overFullScreen"
+        onRequestClose={() => setShowForm(false)}
+      >
+        <TouchableWithoutFeedback onPress={() => { setShowForm(false); }}>
+          <View style={styles.modalBackdrop}>
+            <TouchableWithoutFeedback>
+              <View style={styles.modalContent}>
             <Text style={styles.modalLabel}>New Task</Text>
             <TextInput
+              ref={titleInputRef}
               placeholder="Task title"
               placeholderTextColor="#aaa"
               value={title}
               onChangeText={setTitle}
               style={styles.input}
             />
-            <TouchableOpacity onPress={() => setShowDurationPicker(true)}>
+            <TouchableOpacity
+              onPress={() => {
+                titleInputRef.current?.blur();
+                setShowDurationPicker(true);
+              }}
+            >
               <Text style={styles.input}>{formatDuration(durationMinutes) || 'Pick duration'}</Text>
             </TouchableOpacity>
             {showDurationPicker && (
-              <Modal transparent animationType="fade" onRequestClose={() => setShowDurationPicker(false)}>
-                <View style={styles.modalBackdrop}>
-                  <View style={styles.pickerModal}>
-                    <Text style={styles.modalLabel}>{formatDurationWithZeros(durationMinutes)}</Text>
-                    <Slider
-                      minimumValue={0}
-                      maximumValue={240}
-                      step={5}
-                      value={durationMinutes}
-                      onValueChange={setDurationMinutes}
-                      minimumTrackTintColor="#bb86fc"
-                      style={{ width: '100%', height: 40, marginBottom: 16 }}
-                    />
-                    <AppButton title="Done" onPress={() => setShowDurationPicker(false)} />
+              <Modal
+                transparent
+                animationType="fade"
+                presentationStyle="overFullScreen"
+                onRequestClose={() => setShowDurationPicker(false)}
+              >
+                <TouchableWithoutFeedback onPress={() => setShowDurationPicker(false)}>
+                  <View style={styles.modalBackdrop}>
+                    <TouchableWithoutFeedback>
+                      <View style={styles.pickerModal}>
+                        <Text style={styles.modalLabel}>{formatDurationWithZeros(durationMinutes)}</Text>
+                        <Slider
+                          minimumValue={0}
+                          maximumValue={240}
+                          step={5}
+                          value={durationMinutes}
+                          onValueChange={setDurationMinutes}
+                          minimumTrackTintColor="#bb86fc"
+                          style={{ width: '100%', height: 40, marginBottom: 16 }}
+                        />
+                        <AppButton title="Done" onPress={() => setShowDurationPicker(false)} />
+                      </View>
+                    </TouchableWithoutFeedback>
                   </View>
-                </View>
+                </TouchableWithoutFeedback>
               </Modal>
             )}
 
             <UrgencyPicker value={urgency} onChange={setUrgency} />
 
-            <TouchableOpacity onPress={() => setShowDatePicker(true)}>
+            <TouchableOpacity
+              onPress={() => {
+                titleInputRef.current?.blur();
+                setShowDatePicker(true);
+              }}
+            >
               <Text style={[styles.input, styles.dateInput]}>
                 {dueDate ? formatDate(dueDate) : 'Pick due date'}
               </Text>
@@ -284,18 +314,23 @@ const TasksScreen = forwardRef((props, ref) => {
               <AppButton title="Cancel" onPress={() => { setShowForm(false); setEditingTask(null); }} />
               <AppButton title={editingTask ? 'Save' : 'Add'} onPress={saveTask} />
             </View>
+              </View>
+            </TouchableWithoutFeedback>
           </View>
-        </View>
+        </TouchableWithoutFeedback>
       </Modal>
 
       <Modal
         visible={showHistory}
         animationType="slide"
         transparent
+        presentationStyle="overFullScreen"
         onRequestClose={() => setShowHistory(false)}
       >
-        <View style={styles.modalBackdrop}>
-          <View style={styles.historyModal}>
+        <TouchableWithoutFeedback onPress={() => setShowHistory(false)}>
+          <View style={styles.modalBackdrop}>
+            <TouchableWithoutFeedback>
+              <View style={styles.historyModal}>
             <Text style={styles.modalLabel}>Deleted tasks</Text>
             <FlatList
               data={deletedTasks}
@@ -314,18 +349,23 @@ const TasksScreen = forwardRef((props, ref) => {
               ListEmptyComponent={<Text style={styles.emptyText}>No deleted tasks</Text>}
             />
             <AppButton title="Close" onPress={() => setShowHistory(false)} />
+              </View>
+            </TouchableWithoutFeedback>
           </View>
-        </View>
+        </TouchableWithoutFeedback>
       </Modal>
 
       <Modal
         visible={showSortModal}
         animationType="fade"
         transparent
+        presentationStyle="overFullScreen"
         onRequestClose={() => setShowSortModal(false)}
       >
-        <View style={styles.modalBackdrop}>
-          <View style={styles.sortModal}>
+        <TouchableWithoutFeedback onPress={() => setShowSortModal(false)}>
+          <View style={styles.modalBackdrop}>
+            <TouchableWithoutFeedback>
+              <View style={styles.sortModal}>
             <Text style={styles.modalLabel}>Sort tasks by:</Text>
             <AppButton
               style={styles.sortOption}
@@ -351,8 +391,10 @@ const TasksScreen = forwardRef((props, ref) => {
                 setShowSortModal(false);
               }}
             />
+              </View>
+            </TouchableWithoutFeedback>
           </View>
-        </View>
+        </TouchableWithoutFeedback>
       </Modal>
     </View>
   );

--- a/src/screens/TodoScreen.js
+++ b/src/screens/TodoScreen.js
@@ -6,6 +6,7 @@ import {
   FlatList,
   StyleSheet,
   Modal,
+  TouchableWithoutFeedback,
 } from 'react-native';
 import TodoItem from '../components/TodoItem';
 import AppButton from '../components/AppButton';
@@ -19,6 +20,7 @@ const TodoScreen = forwardRef((props, ref) => {
   const [sortMode, setSortMode] = useState('added');
   const [deletedItems, setDeletedItems] = useState([]);
   const [showHistory, setShowHistory] = useState(false);
+  const textInputRef = React.useRef();
 
   const persistItems = (list) => {
     AsyncStorage.setItem(
@@ -122,11 +124,20 @@ const TodoScreen = forwardRef((props, ref) => {
         contentContainerStyle={{ paddingBottom: 120 }}
       />
 
-      <Modal visible={showForm} animationType="slide" transparent onRequestClose={() => setShowForm(false)}>
-        <View style={styles.modalBackdrop}>
-          <View style={styles.modalContent}>
+      <Modal
+        visible={showForm}
+        animationType="slide"
+        transparent
+        presentationStyle="overFullScreen"
+        onRequestClose={() => setShowForm(false)}
+      >
+        <TouchableWithoutFeedback onPress={() => setShowForm(false)}>
+          <View style={styles.modalBackdrop}>
+            <TouchableWithoutFeedback>
+              <View style={styles.modalContent}>
             <Text style={styles.modalLabel}>New Item</Text>
             <TextInput
+              ref={textInputRef}
               style={styles.input}
               placeholder="Add todo"
               placeholderTextColor="#aaa"
@@ -134,21 +145,39 @@ const TodoScreen = forwardRef((props, ref) => {
               onChangeText={setText}
             />
             <View style={styles.buttonRow}>
-              <AppButton title="Cancel" onPress={() => setShowForm(false)} />
-              <AppButton title="Add" onPress={() => { addItem(); setShowForm(false); }} />
+              <AppButton
+                title="Cancel"
+                onPress={() => {
+                  textInputRef.current?.blur();
+                  setShowForm(false);
+                }}
+              />
+              <AppButton
+                title="Add"
+                onPress={() => {
+                  addItem();
+                  textInputRef.current?.blur();
+                  setShowForm(false);
+                }}
+              />
             </View>
+              </View>
+            </TouchableWithoutFeedback>
           </View>
-        </View>
+        </TouchableWithoutFeedback>
       </Modal>
 
       <Modal
         visible={showHistory}
         animationType="slide"
         transparent
+        presentationStyle="overFullScreen"
         onRequestClose={() => setShowHistory(false)}
       >
-        <View style={styles.modalBackdrop}>
-          <View style={styles.historyModal}>
+        <TouchableWithoutFeedback onPress={() => setShowHistory(false)}>
+          <View style={styles.modalBackdrop}>
+            <TouchableWithoutFeedback>
+              <View style={styles.historyModal}>
             <Text style={styles.modalLabel}>Completed items</Text>
             <FlatList
               data={deletedItems}
@@ -167,18 +196,23 @@ const TodoScreen = forwardRef((props, ref) => {
               ListEmptyComponent={<Text style={styles.emptyText}>No completed items</Text>}
             />
             <AppButton title="Close" onPress={() => setShowHistory(false)} />
+              </View>
+            </TouchableWithoutFeedback>
           </View>
-        </View>
+        </TouchableWithoutFeedback>
       </Modal>
 
       <Modal
         visible={showSortModal}
         animationType="fade"
         transparent
+        presentationStyle="overFullScreen"
         onRequestClose={() => setShowSortModal(false)}
       >
-        <View style={styles.modalBackdrop}>
-          <View style={styles.sortModal}>
+        <TouchableWithoutFeedback onPress={() => setShowSortModal(false)}>
+          <View style={styles.modalBackdrop}>
+            <TouchableWithoutFeedback>
+              <View style={styles.sortModal}>
             <Text style={styles.modalLabel}>Sort items by:</Text>
             <AppButton
               style={styles.sortOption}
@@ -196,8 +230,10 @@ const TodoScreen = forwardRef((props, ref) => {
                 setShowSortModal(false);
               }}
             />
+              </View>
+            </TouchableWithoutFeedback>
           </View>
-        </View>
+        </TouchableWithoutFeedback>
       </Modal>
     </View>
   );

--- a/src/screens/TodoScreen.js
+++ b/src/screens/TodoScreen.js
@@ -8,6 +8,7 @@ import {
   Modal,
   TouchableWithoutFeedback,
   KeyboardAvoidingView,
+  LayoutAnimation,
 } from 'react-native';
 import TodoItem from '../components/TodoItem';
 import AppButton from '../components/AppButton';
@@ -67,6 +68,7 @@ const TodoScreen = forwardRef((props, ref) => {
   };
 
   const toggleItem = (id) => {
+    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
     const removed = items.find(i => i.id === id);
     const newItems = items.filter(i => i.id !== id);
     setItems(newItems);

--- a/src/screens/TodoScreen.js
+++ b/src/screens/TodoScreen.js
@@ -7,6 +7,7 @@ import {
   StyleSheet,
   Modal,
   TouchableWithoutFeedback,
+  KeyboardAvoidingView,
 } from 'react-native';
 import TodoItem from '../components/TodoItem';
 import AppButton from '../components/AppButton';
@@ -134,7 +135,7 @@ const TodoScreen = forwardRef((props, ref) => {
         <TouchableWithoutFeedback onPress={() => setShowForm(false)}>
           <View style={styles.modalBackdrop}>
             <TouchableWithoutFeedback>
-              <View style={styles.modalContent}>
+              <KeyboardAvoidingView enabled={false} style={styles.modalContent}>
             <Text style={styles.modalLabel}>New Item</Text>
             <TextInput
               ref={textInputRef}
@@ -161,7 +162,7 @@ const TodoScreen = forwardRef((props, ref) => {
                 }}
               />
             </View>
-              </View>
+              </KeyboardAvoidingView>
             </TouchableWithoutFeedback>
           </View>
         </TouchableWithoutFeedback>


### PR DESCRIPTION
## Summary
- enable LayoutAnimation on Android for smoother list moves
- keep task form visible when keyboard opens
- blur title field when opening other pickers
- close popups when tapping outside

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846c1d145108320a335f75e1394441f