### PR TITLE
Add Jest tests for components and utilities

### DIFF
--- a/__tests__/__snapshots__/components.test.js.snap
+++ b/__tests__/__snapshots__/components.test.js.snap
@@ -1,0 +1,672 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component snapshots AppButton 1`] = `
+<View
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": undefined,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    {
+      "alignItems": "center",
+      "backgroundColor": "#bb86fc",
+      "borderRadius": 8,
+      "marginHorizontal": 4,
+      "opacity": 1,
+      "paddingHorizontal": 12,
+      "paddingVertical": 10,
+    }
+  }
+>
+  <Text
+    style={
+      [
+        {
+          "color": "#fff",
+          "fontSize": 16,
+          "fontWeight": "bold",
+        },
+        undefined,
+      ]
+    }
+  >
+    OK
+  </Text>
+</View>
+`;
+
+exports[`Component snapshots FloatingActionButton 1`] = `
+<View
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": undefined,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    {
+      "alignItems": "center",
+      "backgroundColor": "#bb86fc",
+      "borderRadius": 8,
+      "bottom": 32,
+      "elevation": 4,
+      "height": 56,
+      "justifyContent": "center",
+      "opacity": 1,
+      "position": "absolute",
+      "right": 32,
+      "width": 56,
+    }
+  }
+>
+  <Text
+    style={
+      {
+        "color": "#fff",
+        "fontSize": 32,
+        "lineHeight": 32,
+      }
+    }
+  >
+    +
+  </Text>
+</View>
+`;
+
+exports[`Component snapshots TaskItem 1`] = `
+<View
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": undefined,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    {
+      "opacity": 1,
+    }
+  }
+>
+  <View
+    collapsable={false}
+    style={
+      {
+        "alignItems": "center",
+        "backgroundColor": "#1e1e1e",
+        "borderRadius": 8,
+        "flexDirection": "row",
+        "marginVertical": 6,
+        "opacity": 1,
+        "paddingLeft": 16,
+        "paddingRight": 8,
+        "paddingVertical": 12,
+        "transform": [
+          {
+            "translateX": 0,
+          },
+        ],
+      }
+    }
+  >
+    <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "opacity": 1,
+          "padding": 8,
+        }
+      }
+    >
+      <Checkbox
+        onValueChange={[Function]}
+        style={
+          {
+            "height": 20,
+            "width": 20,
+          }
+        }
+        value={false}
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginLeft": 16,
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "#fff",
+            "fontSize": 16,
+            "fontWeight": "bold",
+          }
+        }
+      >
+        Test
+      </Text>
+      <Text
+        style={
+          {
+            "color": "#aaa",
+            "fontSize": 12,
+          }
+        }
+      >
+        1h
+      </Text>
+      <Text
+        style={
+          {
+            "color": "#aaa",
+            "fontSize": 12,
+          }
+        }
+      >
+        Due 
+        03/01/2023
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "marginLeft": 8,
+        }
+      }
+    >
+      <View
+        style={
+          [
+            {
+              "borderRadius": 6,
+              "height": 12,
+              "marginHorizontal": 2,
+              "width": 12,
+            },
+            {
+              "backgroundColor": "rgb(255, 0, 0)",
+            },
+          ]
+        }
+      />
+      <View
+        style={
+          [
+            {
+              "borderRadius": 6,
+              "height": 12,
+              "marginHorizontal": 2,
+              "width": 12,
+            },
+            {
+              "backgroundColor": "rgb(255, 0, 0)",
+            },
+          ]
+        }
+      />
+      <View
+        style={
+          [
+            {
+              "borderRadius": 6,
+              "height": 12,
+              "marginHorizontal": 2,
+              "width": 12,
+            },
+            {
+              "backgroundColor": "rgb(255, 0, 0)",
+            },
+          ]
+        }
+      />
+      <View
+        style={
+          [
+            {
+              "borderRadius": 6,
+              "height": 12,
+              "marginHorizontal": 2,
+              "width": 12,
+            },
+            {
+              "backgroundColor": "rgb(255, 0, 0)",
+            },
+          ]
+        }
+      />
+      <View
+        style={
+          [
+            {
+              "borderRadius": 6,
+              "height": 12,
+              "marginHorizontal": 2,
+              "width": 12,
+            },
+            {
+              "backgroundColor": "rgb(255, 0, 0)",
+            },
+          ]
+        }
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Component snapshots TodoItem 1`] = `
+<View
+  collapsable={false}
+  style={
+    {
+      "alignItems": "center",
+      "backgroundColor": "#1e1e1e",
+      "borderRadius": 8,
+      "flexDirection": "row",
+      "marginVertical": 6,
+      "opacity": 1,
+      "paddingLeft": 16,
+      "paddingRight": 8,
+      "paddingVertical": 12,
+      "transform": [
+        {
+          "translateX": 0,
+        },
+      ],
+    }
+  }
+>
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      {
+        "opacity": 1,
+        "padding": 8,
+      }
+    }
+  >
+    <Checkbox
+      onValueChange={[Function]}
+      style={
+        {
+          "height": 20,
+          "width": 20,
+        }
+      }
+      value={false}
+    />
+  </View>
+  <View
+    style={
+      {
+        "flex": 1,
+        "marginLeft": 16,
+      }
+    }
+  >
+    <TextInput
+      editable={false}
+      style={
+        {
+          "color": "#fff",
+          "fontSize": 16,
+        }
+      }
+      value="Do"
+    />
+  </View>
+</View>
+`;
+
+exports[`Component snapshots UrgencyPicker 1`] = `
+<View
+  style={
+    {
+      "flexDirection": "row",
+      "justifyContent": "space-between",
+      "marginVertical": 8,
+    }
+  }
+>
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      [
+        {
+          "borderRadius": 10,
+          "height": 20,
+          "marginHorizontal": 2,
+          "width": 20,
+        },
+        {
+          "backgroundColor": "rgb(255, 255, 0)",
+        },
+      ]
+    }
+  />
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      [
+        {
+          "borderRadius": 10,
+          "height": 20,
+          "marginHorizontal": 2,
+          "width": 20,
+        },
+        {
+          "backgroundColor": "rgb(255, 255, 0)",
+        },
+      ]
+    }
+  />
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      [
+        {
+          "borderRadius": 10,
+          "height": 20,
+          "marginHorizontal": 2,
+          "width": 20,
+        },
+        {
+          "backgroundColor": "rgb(255, 255, 0)",
+        },
+      ]
+    }
+  />
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      [
+        {
+          "borderRadius": 10,
+          "height": 20,
+          "marginHorizontal": 2,
+          "width": 20,
+        },
+        {
+          "backgroundColor": "#555",
+        },
+      ]
+    }
+  />
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      [
+        {
+          "borderRadius": 10,
+          "height": 20,
+          "marginHorizontal": 2,
+          "width": 20,
+        },
+        {
+          "backgroundColor": "#555",
+        },
+      ]
+    }
+  />
+</View>
+`;

--- a/__tests__/__snapshots__/screens.test.js.snap
+++ b/__tests__/__snapshots__/screens.test.js.snap
@@ -1,0 +1,380 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Screen snapshots TasksScreen 1`] = `
+<View
+  style={
+    {
+      "backgroundColor": "#121212",
+      "flex": 1,
+      "padding": 20,
+    }
+  }
+>
+  <View
+    style={
+      {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "justifyContent": "space-between",
+        "marginBottom": 12,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "#fff",
+          "fontSize": 24,
+          "fontWeight": "bold",
+        }
+      }
+    >
+      Tasks
+    </Text>
+    <View
+      style={
+        {
+          "alignItems": "center",
+          "flexDirection": "row",
+        }
+      }
+    >
+      <View
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "transparent",
+            "borderColor": "#bb86fc",
+            "borderRadius": 8,
+            "borderWidth": 1,
+            "marginHorizontal": 4,
+            "opacity": 1,
+            "paddingHorizontal": 8,
+            "paddingVertical": 6,
+          }
+        }
+      >
+        <Text
+          style={
+            [
+              {
+                "color": "#fff",
+                "fontSize": 16,
+                "fontWeight": "bold",
+              },
+              {
+                "color": "#bb86fc",
+                "fontSize": 14,
+              },
+            ]
+          }
+        >
+          History
+        </Text>
+      </View>
+      <View
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "transparent",
+            "borderColor": "#bb86fc",
+            "borderRadius": 8,
+            "borderWidth": 1,
+            "marginHorizontal": 4,
+            "opacity": 1,
+            "paddingHorizontal": 8,
+            "paddingVertical": 6,
+          }
+        }
+      >
+        <Text
+          style={
+            [
+              {
+                "color": "#fff",
+                "fontSize": 16,
+                "fontWeight": "bold",
+              },
+              {
+                "color": "#bb86fc",
+                "fontSize": 14,
+              },
+            ]
+          }
+        >
+          Sort: Priority
+        </Text>
+      </View>
+    </View>
+  </View>
+  <RCTScrollView
+    contentContainerStyle={
+      {
+        "paddingBottom": 120,
+      }
+    }
+    data={[]}
+    getItem={[Function]}
+    getItemCount={[Function]}
+    keyExtractor={[Function]}
+    onContentSizeChange={[Function]}
+    onLayout={[Function]}
+    onMomentumScrollBegin={[Function]}
+    onMomentumScrollEnd={[Function]}
+    onScroll={[Function]}
+    onScrollBeginDrag={[Function]}
+    onScrollEndDrag={[Function]}
+    removeClippedSubviews={false}
+    renderItem={[Function]}
+    scrollEventThrottle={0.0001}
+    stickyHeaderIndices={[]}
+    viewabilityConfigCallbackPairs={[]}
+  >
+    <View />
+  </RCTScrollView>
+</View>
+`;
+
+exports[`Screen snapshots TodoScreen 1`] = `
+<View
+  style={
+    {
+      "backgroundColor": "#121212",
+      "flex": 1,
+      "padding": 20,
+    }
+  }
+>
+  <View
+    style={
+      {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "justifyContent": "space-between",
+        "marginBottom": 12,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "#fff",
+          "fontSize": 24,
+          "fontWeight": "bold",
+          "marginBottom": 12,
+        }
+      }
+    >
+      Todo
+    </Text>
+    <View
+      style={
+        {
+          "alignItems": "center",
+          "flexDirection": "row",
+        }
+      }
+    >
+      <View
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "transparent",
+            "borderColor": "#bb86fc",
+            "borderRadius": 8,
+            "borderWidth": 1,
+            "marginHorizontal": 4,
+            "opacity": 1,
+            "paddingHorizontal": 8,
+            "paddingVertical": 6,
+          }
+        }
+      >
+        <Text
+          style={
+            [
+              {
+                "color": "#fff",
+                "fontSize": 16,
+                "fontWeight": "bold",
+              },
+              {
+                "color": "#bb86fc",
+                "fontSize": 14,
+              },
+            ]
+          }
+        >
+          History
+        </Text>
+      </View>
+      <View
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "transparent",
+            "borderColor": "#bb86fc",
+            "borderRadius": 8,
+            "borderWidth": 1,
+            "marginHorizontal": 4,
+            "opacity": 1,
+            "paddingHorizontal": 8,
+            "paddingVertical": 6,
+          }
+        }
+      >
+        <Text
+          style={
+            [
+              {
+                "color": "#fff",
+                "fontSize": 16,
+                "fontWeight": "bold",
+              },
+              {
+                "color": "#bb86fc",
+                "fontSize": 14,
+              },
+            ]
+          }
+        >
+          Sort: Latest
+        </Text>
+      </View>
+    </View>
+  </View>
+  <RCTScrollView
+    contentContainerStyle={
+      {
+        "paddingBottom": 120,
+      }
+    }
+    data={[]}
+    getItem={[Function]}
+    getItemCount={[Function]}
+    keyExtractor={[Function]}
+    onContentSizeChange={[Function]}
+    onLayout={[Function]}
+    onMomentumScrollBegin={[Function]}
+    onMomentumScrollEnd={[Function]}
+    onScroll={[Function]}
+    onScrollBeginDrag={[Function]}
+    onScrollEndDrag={[Function]}
+    removeClippedSubviews={false}
+    renderItem={[Function]}
+    scrollEventThrottle={0.0001}
+    stickyHeaderIndices={[]}
+    viewabilityConfigCallbackPairs={[]}
+  >
+    <View />
+  </RCTScrollView>
+</View>
+`;

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import App from '../src/App';
+
+jest.mock('expo-checkbox', () => 'Checkbox');
+jest.mock('@react-native-async-storage/async-storage', () => require('@react-native-async-storage/async-storage/jest/async-storage-mock'));
+jest.mock('@react-native-community/datetimepicker', () => 'DateTimePicker');
+jest.mock('@react-native-community/slider', () => 'Slider');
+
+test('App renders', () => {
+  let tree;
+  act(() => {
+    tree = renderer.create(<App />);
+  });
+  expect(tree.toJSON()).toBeTruthy();
+});

--- a/__tests__/components.test.js
+++ b/__tests__/components.test.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import AppButton from '../src/components/AppButton';
+import FloatingActionButton from '../src/components/FloatingActionButton';
+import TaskItem from '../src/components/TaskItem';
+import TodoItem from '../src/components/TodoItem';
+import UrgencyPicker from '../src/components/UrgencyPicker';
+
+jest.mock('expo-checkbox', () => 'Checkbox');
+
+const sampleTask = {
+  title: 'Test',
+  duration: '1h',
+  urgency: 3,
+  created: '2023-01-01T00:00:00Z',
+  dueDate: '2023-01-03T00:00:00Z',
+};
+
+describe('Component snapshots', () => {
+  test('AppButton', () => {
+    let tree;
+    act(() => {
+      tree = renderer.create(<AppButton title="OK" onPress={() => {}} />);
+    });
+    expect(tree.toJSON()).toMatchSnapshot();
+  });
+
+  test('FloatingActionButton', () => {
+    let tree;
+    act(() => {
+      tree = renderer.create(<FloatingActionButton onPress={() => {}} />);
+    });
+    expect(tree.toJSON()).toMatchSnapshot();
+  });
+
+  test('TaskItem', () => {
+    let tree;
+    act(() => {
+      tree = renderer.create(
+        <TaskItem task={sampleTask} onComplete={() => {}} onPress={() => {}} />
+      );
+    });
+    expect(tree.toJSON()).toMatchSnapshot();
+  });
+
+  test('TodoItem', () => {
+    let tree;
+    act(() => {
+      tree = renderer.create(
+        <TodoItem item={{ id: '1', text: 'Do', animateIn: false }} onToggle={() => {}} />
+      );
+    });
+    expect(tree.toJSON()).toMatchSnapshot();
+  });
+
+  test('UrgencyPicker', () => {
+    let tree;
+    act(() => {
+      tree = renderer.create(<UrgencyPicker value={3} onChange={() => {}} />);
+    });
+    expect(tree.toJSON()).toMatchSnapshot();
+  });
+});

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,0 +1,15 @@
+jest.mock('expo', () => ({ registerRootComponent: jest.fn() }));
+jest.mock('@react-native-async-storage/async-storage', () => require('@react-native-async-storage/async-storage/jest/async-storage-mock'));
+jest.mock('@react-native-community/datetimepicker', () => 'DateTimePicker');
+jest.mock('@react-native-community/slider', () => 'Slider');
+jest.mock('expo-checkbox', () => 'Checkbox');
+import { registerRootComponent } from 'expo';
+import * as widget from '../src/widgets/HomeWidget';
+
+test('index registers root and widget', () => {
+  const spy = jest.spyOn(widget, 'registerWidget').mockImplementation(() => {});
+  require('../index');
+  expect(registerRootComponent).toHaveBeenCalled();
+  expect(spy).toHaveBeenCalled();
+  spy.mockRestore();
+});

--- a/__tests__/screens.test.js
+++ b/__tests__/screens.test.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import TasksScreen from '../src/screens/TasksScreen';
+import TodoScreen from '../src/screens/TodoScreen';
+
+jest.mock('@react-native-async-storage/async-storage', () => require('@react-native-async-storage/async-storage/jest/async-storage-mock'));
+jest.mock('@react-native-community/datetimepicker', () => 'DateTimePicker');
+jest.mock('@react-native-community/slider', () => 'Slider');
+jest.mock('expo-checkbox', () => 'Checkbox');
+
+describe('Screen snapshots', () => {
+  test('TasksScreen', async () => {
+    let tree;
+    await act(async () => {
+      tree = renderer.create(<TasksScreen />);
+    });
+    expect(tree.toJSON()).toMatchSnapshot();
+  });
+
+  test('TodoScreen', async () => {
+    let tree;
+    await act(async () => {
+      tree = renderer.create(<TodoScreen />);
+    });
+    expect(tree.toJSON()).toMatchSnapshot();
+  });
+});

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -1,0 +1,56 @@
+jest.mock('@react-native-async-storage/async-storage', () => require('@react-native-async-storage/async-storage/jest/async-storage-mock'));
+jest.mock('@react-native-community/datetimepicker', () => 'DateTimePicker');
+jest.mock('@react-native-community/slider', () => 'Slider');
+jest.mock('expo-checkbox', () => 'Checkbox');
+
+import { colorFor, computeUrgency, formatDate } from '../src/components/TaskItem';
+import { formatDuration, parseDuration, formatDurationWithZeros } from '../src/screens/TasksScreen';
+
+describe('Task utilities', () => {
+  test('colorFor generates gradient', () => {
+    expect(colorFor(1)).toBe('rgb(0, 255, 0)');
+    expect(colorFor(3)).toBe('rgb(255, 255, 0)');
+    expect(colorFor(5)).toBe('rgb(255, 0, 0)');
+  });
+
+  test('formatDate formats yyyy-mm-dd', () => {
+    const date = '2023-05-07T00:00:00Z';
+    expect(formatDate(date)).toBe('07/05/2023');
+  });
+
+  test('computeUrgency increases as deadline approaches', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2023-01-02T00:00:00Z'));
+    const task = {
+      urgency: 2,
+      created: '2023-01-01T00:00:00Z',
+      dueDate: '2023-01-03T00:00:00Z',
+    };
+    expect(computeUrgency(task)).toBe(3);
+    jest.useRealTimers();
+  });
+
+  test('computeUrgency without due date', () => {
+    const task = { urgency: 4 };
+    expect(computeUrgency(task)).toBe(4);
+  });
+});
+
+describe('Duration helpers', () => {
+  test('parseDuration works with hours and minutes', () => {
+    expect(parseDuration('1h 30m')).toBe(90);
+    expect(parseDuration('45m')).toBe(45);
+    expect(parseDuration('bad')).toBe(0);
+  });
+
+  test('formatDuration returns compact string', () => {
+    expect(formatDuration(90)).toBe('1h 30m');
+    expect(formatDuration(45)).toBe('45m');
+    expect(formatDuration(0)).toBe('0m');
+  });
+
+  test('formatDurationWithZeros pads minutes', () => {
+    expect(formatDurationWithZeros(90)).toBe('1h 30m');
+    expect(formatDurationWithZeros(5)).toBe('05m');
+    expect(formatDurationWithZeros(65)).toBe('1h 05m');
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "react-native-tab-view": "^4.1.1"
       },
       "devDependencies": {
-        "@babel/core": "7.21.5",
+        "@babel/core": "^7.22.10",
         "jest": "29.7.0",
         "jest-expo": "~53.0.5",
         "react-test-renderer": "19.0.0"
@@ -79,25 +79,26 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.5.tgz",
-      "integrity": "sha512-9M398B/QH5DlfCOTKDZT1ozXr0x8uBEeFd+dJraGUZGiaNpGCDVGCc14hZexsMblw3XxltJ+6kSvogp9J+5a9g==",
+      "version": "7.22.10",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.10.tgz",
+      "integrity": "sha512-fTmqbbUBAwCcre6zPzNngvsI0aNrPZe77AeqvDxWM9Nm+04RrJ3CAmGHA9f7lJQY6ZMhRztNemy4uslDxTX4Qw==",
+      "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.21.4",
-        "@babel/generator": "^7.21.5",
-        "@babel/helper-compilation-targets": "^7.21.5",
-        "@babel/helper-module-transforms": "^7.21.5",
-        "@babel/helpers": "^7.21.5",
-        "@babel/parser": "^7.21.5",
-        "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.21.5",
-        "@babel/types": "^7.21.5",
+        "@babel/code-frame": "^7.22.10",
+        "@babel/generator": "^7.22.10",
+        "@babel/helper-compilation-targets": "^7.22.10",
+        "@babel/helper-module-transforms": "^7.22.9",
+        "@babel/helpers": "^7.22.10",
+        "@babel/parser": "^7.22.10",
+        "@babel/template": "^7.22.5",
+        "@babel/traverse": "^7.22.10",
+        "@babel/types": "^7.22.10",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
         "json5": "^2.2.2",
-        "semver": "^6.3.0"
+        "semver": "^6.3.1"
       },
       "engines": {
         "node": ">=6.9.0"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "react-native-tab-view": "^4.1.1"
   },
   "devDependencies": {
-    "@babel/core": "7.21.5",
+    "@babel/core": "^7.22.10",
     "jest": "29.7.0",
     "jest-expo": "~53.0.5",
     "react-test-renderer": "19.0.0"

--- a/src/components/TaskItem.js
+++ b/src/components/TaskItem.js
@@ -150,3 +150,5 @@ const styles = StyleSheet.create({
     height: 20,
   },
 });
+
+export { formatDate, colorFor, computeUrgency };

--- a/src/components/UrgencyPicker.js
+++ b/src/components/UrgencyPicker.js
@@ -38,3 +38,5 @@ const styles = StyleSheet.create({
     marginHorizontal: 2,
   },
 });
+
+export { colorFor };

--- a/src/screens/TasksScreen.js
+++ b/src/screens/TasksScreen.js
@@ -359,6 +359,7 @@ const TasksScreen = forwardRef((props, ref) => {
 });
 
 export default TasksScreen;
+export { formatDuration, parseDuration, formatDurationWithZeros, formatDate };
 
 const styles = StyleSheet.create({
   container: { flex: 1, padding: 20, backgroundColor: '#121212' },


### PR DESCRIPTION
## Summary
- export helper functions from components and screens
- add Jest tests and snapshots for core components and screens
- ensure root registration tested
- upgrade `@babel/core` for Jest compatibility

## Testing
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_685a8c3bdfac832094a6efcde2d513b9